### PR TITLE
Caller can explicitly specify the name of added classes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,8 +60,8 @@ const create = (options = {}) => {
     glob[name] && glob[name].fromJSON;
 
 
-  const addClass = (Class) => {
-    const {name} = Class;
+  const addClass = (Class, className) => {
+    const name = className || Class.name;
     if (!isValidClassName(name)) {
       throw new ConfigError("'name' must be provided to serialize custom class.");
     }


### PR DESCRIPTION
When minifying, class name is changed and cannot be relied on. This PR attempts to fix it by allowing an explicit name to be set, defaulting on Class.name if none is provided.
